### PR TITLE
Use UNWIND strategy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ executors:
         environment:
           - BUNDLE_VERSION: "~> 1.17"
           - NEO4J_URL: "http://127.0.0.1:7474"
-      - image: neo4j:4.3.9-enterprise
+      - image: neo4j:4.4.6-enterprise
         environment:
           NEO4J_ACCEPT_LICENSE_AGREEMENT: "yes"
           NEO4J_AUTH: "none"

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @doximity/mofo_profiles

--- a/README.md
+++ b/README.md
@@ -82,12 +82,68 @@ Neo4j::Http::Client.find_nodes_by(label: "User", name: "Testing")
 Neo4j::Http::Client.delete_node(node)
 ```
 
+### Upsert and delete nodes in batch via UNWIND
+
+You can describe a node and then pass an array of objects to build nodes that pattern.
+When calling upsert_node, the variable `node` only needs to contain the `label:` keyword argument.
+
+```ruby
+node = Neo4j::Http::Node.new(label: "User")
+Neo4j::Http::Client.upsert_node(node, unwind: [
+  {
+    uuid: 1,
+    name: "Foo"
+  },
+  {
+    uuid: 2,
+    name: "Bar"
+  },
+  ...
+])
+```
+
 ### Create a new relationship, also creating the nodes if they do not exist
 ```ruby
 user1 = Neo4j::Http::Node.new(label: "User", uuid: SecureRandom.uuid)
 user2 = Neo4j::Http::Node.new(label: "User", uuid: SecureRandom.uuid)
 relationship = Neo4j::Http::Relationship.new(label: "KNOWS")
 Neo4j::Http::Client.upsert_relationship(relationship: relationship, from: user1, to: user2, create_nodes: true)
+```
+
+### Upsert and delete relationships in batch via UNWIND
+
+You can describe two nodes, and a relationship and then pass an array of objects to build that pattern.
+When calling upsert_relationship, the variable `node`, and `relationship` only needs to contain the `label:` keyword argument.
+
+```ruby
+from = Neo4j::Http::Node.new(label: "User")
+to = Neo4j::Http::Node.new(label: "Place")
+relationship = Neo4j::Http::Relationship.new(label: "TRAVELS_TO")
+Neo4j::Http::Client.upsert_relationship(node, unwind: [
+  {
+    from: {
+      uuid: 1
+    },
+    to: {
+      from: 2
+    },
+    relationship: {
+      vehicle: "car"
+    }
+  },
+  {
+    from: {
+      uuid: 3
+    },
+    to: {
+      from: 4
+    },
+    relationship: {
+      vehicle: "plane"
+    }
+  },
+  ...
+])
 ```
 
 ### Find an existing relationship

--- a/lib/neo4j/http/client.rb
+++ b/lib/neo4j/http/client.rb
@@ -5,7 +5,8 @@ module Neo4j
     class Client
       CYPHER_CLIENT_METHODS = %i[execute_cypher].freeze
       NODE_CLIENT_METHODS = %i[delete_node find_node_by find_nodes_by upsert_node].freeze
-      RELATIONSHIP_CLIENT_METHODS = %i[delete_relationship upsert_relationship delete_relationship_on_primary_key].freeze
+      RELATIONSHIP_CLIENT_METHODS = %i[delete_relationship upsert_relationship
+        delete_relationship_on_primary_key].freeze
       CLIENT_METHODS = (CYPHER_CLIENT_METHODS + NODE_CLIENT_METHODS + RELATIONSHIP_CLIENT_METHODS).freeze
 
       class << self

--- a/spec/neo4j/http/node_client_spec.rb
+++ b/spec/neo4j/http/node_client_spec.rb
@@ -66,38 +66,6 @@ RSpec.describe Neo4j::Http::NodeClient, type: :uses_neo4j do
       expect(results.map {|result| result.dig("node", "name") }).to contain_exactly("Foo", "Bar", "Baz")
     end
 
-    it "rolls back during a schema violation" do
-      Neo4j::Http::Client.execute_cypher <<~CYPHER
-        MATCH (n:Foo) DETACH DELETE n
-      CYPHER
-
-      Neo4j::Http::Client.execute_cypher <<~CYPHER
-        CREATE CONSTRAINT IF NOT EXISTS FOR (n:Foo) REQUIRE n.name IS UNIQUE
-      CYPHER
-
-      node_in = Neo4j::Http::Node.new(label: "Foo")
-
-      expect {
-        client.upsert_node(node_in, unwind: [
-          {
-            uuid: 1,
-            name: "Bar"
-          },
-          {
-            uuid: 2,
-            name: "Foo",
-          },
-          {
-            uuid: 3,
-            name: "Foo"
-          }
-        ])
-      }.to raise_error(Neo4j::Http::Errors::Neo::ClientError::Schema::ConstraintValidationFailed)
-
-      results = cypher_client.execute_cypher("MATCH (node:Test) WHERE node.uuid IN $uuid RETURN node", uuid: [1, 2, 3])
-      expect(results.length).to eq(0)
-    end
-
     it "updates via unwind" do
       # Insert a node so it is existing
       node_in = Neo4j::Http::Node.new(label: "Test", uuid: 1, name: "replaceme")
@@ -121,6 +89,48 @@ RSpec.describe Neo4j::Http::NodeClient, type: :uses_neo4j do
 
       results = cypher_client.execute_cypher("MATCH (node:Test { uuid: $uuid }) RETURN node", uuid: 2)
       expect(results.map {|result| result.dig("node", "name") }).to contain_exactly("Bar")
+    end
+  end
+
+  describe "unwind rollback" do
+    around do |example|
+      Neo4j::Http::Client.execute_cypher <<~CYPHER
+        MATCH (n:Foo) DETACH DELETE n
+      CYPHER
+
+      Neo4j::Http::Client.execute_cypher <<~CYPHER
+        CREATE CONSTRAINT test IF NOT EXISTS FOR (n:Foo) REQUIRE n.name IS UNIQUE
+      CYPHER
+
+      example.run
+
+      Neo4j::Http::Client.execute_cypher <<~CYPHER
+        DROP CONSTRAINT test
+      CYPHER
+    end
+
+    it "rolls back during a schema violation" do
+      node_in = Neo4j::Http::Node.new(label: "Foo")
+
+      expect {
+        client.upsert_node(node_in, unwind: [
+          {
+            uuid: 1,
+            name: "Bar"
+          },
+          {
+            uuid: 2,
+            name: "Foo",
+          },
+          {
+            uuid: 3,
+            name: "Foo"
+          }
+        ])
+      }.to raise_error(Neo4j::Http::Errors::Neo::ClientError::Schema::ConstraintValidationFailed)
+
+      results = cypher_client.execute_cypher("MATCH (node:Test) WHERE node.uuid IN $uuid RETURN node", uuid: [1, 2, 3])
+      expect(results.length).to eq(0)
     end
   end
 

--- a/spec/neo4j/http/node_client_spec.rb
+++ b/spec/neo4j/http/node_client_spec.rb
@@ -46,14 +46,14 @@ RSpec.describe Neo4j::Http::NodeClient, type: :uses_neo4j do
 
     it "accepts an unwind argument" do
       node_in = Neo4j::Http::Node.new(label: "Test")
-      node = client.upsert_node(node_in, unwind: [
+      client.upsert_node(node_in, unwind: [
         {
           uuid: 1,
           name: "Foo"
         },
         {
           uuid: 2,
-          name: "Bar",
+          name: "Bar"
         },
         {
           uuid: 3,
@@ -63,16 +63,16 @@ RSpec.describe Neo4j::Http::NodeClient, type: :uses_neo4j do
 
       results = cypher_client.execute_cypher("MATCH (node:Test) WHERE node.uuid IN $uuid RETURN node", uuid: [1, 2, 3])
       expect(results.length).to eq(3)
-      expect(results.map {|result| result.dig("node", "name") }).to contain_exactly("Foo", "Bar", "Baz")
+      expect(results.map { |result| result.dig("node", "name") }).to contain_exactly("Foo", "Bar", "Baz")
     end
 
     it "updates via unwind" do
       # Insert a node so it is existing
       node_in = Neo4j::Http::Node.new(label: "Test", uuid: 1, name: "replaceme")
-      node1 = client.upsert_node(node_in)
+      client.upsert_node(node_in)
 
       node_in = Neo4j::Http::Node.new(label: "Test")
-      node = client.upsert_node(node_in, unwind: [
+      client.upsert_node(node_in, unwind: [
         {
           # update the existing node
           uuid: 1,
@@ -80,15 +80,15 @@ RSpec.describe Neo4j::Http::NodeClient, type: :uses_neo4j do
         },
         {
           uuid: 2,
-          name: "Bar",
+          name: "Bar"
         }
       ])
 
       results = cypher_client.execute_cypher("MATCH (node:Test { uuid: $uuid }) RETURN node", uuid: 1)
-      expect(results.map {|result| result.dig("node", "name") }).to contain_exactly("Foo")
+      expect(results.map { |result| result.dig("node", "name") }).to contain_exactly("Foo")
 
       results = cypher_client.execute_cypher("MATCH (node:Test { uuid: $uuid }) RETURN node", uuid: 2)
-      expect(results.map {|result| result.dig("node", "name") }).to contain_exactly("Bar")
+      expect(results.map { |result| result.dig("node", "name") }).to contain_exactly("Bar")
     end
   end
 
@@ -120,7 +120,7 @@ RSpec.describe Neo4j::Http::NodeClient, type: :uses_neo4j do
           },
           {
             uuid: 2,
-            name: "Foo",
+            name: "Foo"
           },
           {
             uuid: 3,
@@ -138,7 +138,7 @@ RSpec.describe Neo4j::Http::NodeClient, type: :uses_neo4j do
     it "removes a single node" do
       # Insert a node so it is existing
       node_in = Neo4j::Http::Node.new(label: "Test", uuid: 1, name: "Foo")
-      node1 = client.upsert_node(node_in)
+      client.upsert_node(node_in)
 
       results = cypher_client.execute_cypher("MATCH (node:Test {uuid: $uuid}) RETURN node", uuid: 1)
       expect(results.length).to eq(1)
@@ -152,19 +152,19 @@ RSpec.describe Neo4j::Http::NodeClient, type: :uses_neo4j do
     it "removes via unwind" do
       # Insert a node so it is existing
       node_in = Neo4j::Http::Node.new(label: "Test", uuid: 1, name: "Foo")
-      node1 = client.upsert_node(node_in)
+      client.upsert_node(node_in)
 
       node_in = Neo4j::Http::Node.new(label: "Test", uuid: 2, name: "Bar")
-      node1 = client.upsert_node(node_in)
+      client.upsert_node(node_in)
 
       node_in = Neo4j::Http::Node.new(label: "Test", uuid: 3, name: "Baz")
-      node1 = client.upsert_node(node_in)
+      client.upsert_node(node_in)
 
       results = cypher_client.execute_cypher("MATCH (node:Test) WHERE node.uuid IN $uuid RETURN node", uuid: [1, 2, 3])
       expect(results.length).to eq(3)
 
       node_in = Neo4j::Http::Node.new(label: "Test")
-      node = client.delete_node(node_in, unwind: [
+      client.delete_node(node_in, unwind: [
         {
           uuid: 1
         },

--- a/spec/neo4j/http/relationship_client_spec.rb
+++ b/spec/neo4j/http/relationship_client_spec.rb
@@ -87,10 +87,12 @@ RSpec.describe Neo4j::Http::RelationshipClient do
       create_node(from)
       create_node(to)
 
-      relationship_friend = Neo4j::Http::Relationship.new(label: "KNOWS", primary_key_name: "uuid", uuid: "FriendUuid", how: "friend")
+      relationship_friend = Neo4j::Http::Relationship.new(label: "KNOWS", primary_key_name: "uuid", uuid: "FriendUuid",
+        how: "friend")
       edge_a = create_relationship(from, relationship_friend, to)
 
-      relationship_colleague = Neo4j::Http::Relationship.new(label: "KNOWS", primary_key_name: "uuid", uuid: "ColleagueUuid", how: "colleague")
+      relationship_colleague = Neo4j::Http::Relationship.new(label: "KNOWS", primary_key_name: "uuid",
+        uuid: "ColleagueUuid", how: "colleague")
       edge_b = create_relationship(from, relationship_colleague, to)
 
       expect(edge_a["relationship"]["uuid"]).to eq("FriendUuid")
@@ -143,7 +145,7 @@ RSpec.describe Neo4j::Http::RelationshipClient do
           relationship: relationship,
           from: Neo4j::Http::Node.new(label: "Bot"),
           to: Neo4j::Http::Node.new(label: "Bot"),
-          create_nodes: true,                                 # <-- this is the subject of the test
+          create_nodes: true, # <-- this is the subject of the test
           unwind: [
             {
               from: {
@@ -231,7 +233,7 @@ RSpec.describe Neo4j::Http::RelationshipClient do
     end
 
     it "updates two different relationships on different nodes" do
-      results = client.upsert_relationship(
+      client.upsert_relationship(
         relationship: relationship,
         from: Neo4j::Http::Node.new(label: "Bot"),
         to: Neo4j::Http::Node.new(label: "Bot"),
@@ -358,8 +360,8 @@ RSpec.describe Neo4j::Http::RelationshipClient do
 
       expect(results.length).to eq(2)
 
-      edge_a = results.detect { |result| result["relationship"]["uuid"] == "FriendUuid"}
-      edge_b = results.detect { |result| result["relationship"]["uuid"] == "ColleagueUuid"}
+      edge_a = results.detect { |result| result["relationship"]["uuid"] == "FriendUuid" }
+      edge_b = results.detect { |result| result["relationship"]["uuid"] == "ColleagueUuid" }
 
       expect(edge_a["relationship"]["uuid"]).to eq("FriendUuid")
       expect(edge_a["relationship"]["how"]).to eq("friend")
@@ -493,7 +495,6 @@ RSpec.describe Neo4j::Http::RelationshipClient do
 
       expect(client.find_relationships(relationship: relationship, from: from, to: to).count).to eq(2)
 
-      node = Neo4j::Http::Node.new(label: "Bot")
       relationship = Neo4j::Http::Relationship.new(label: "KNOWS", primary_key_name: "how")
       client.delete_relationship_on_primary_key(relationship: relationship, unwind: [
         {


### PR DESCRIPTION
JIRA story: https://doximity.atlassian.net/browse/MOFONETPROFILES-294

# Overview

Use UNWIND strategy

# Technical Information

This is somewhat different from upsert_node but it is conceptually still an upsert node operation with a different payload so I've opted to use a kwarg to support this.

```
Neo4j::Http::Client.upsert_node(node, unwind: [{ ... }, { ... }])
```

The node is still required because we pull some important pieces off of this including the label and key name (primary key)

This is taken from https://medium.com/neo4j/5-tips-tricks-for-fast-batched-updates-of-graph-structures-with-neo4j-and-cypher-73c7f693c8cc