### PR TITLE
Give checks permission to version health workflow

### DIFF
--- a/.github/workflows/version_health.yml
+++ b/.github/workflows/version_health.yml
@@ -10,6 +10,7 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
+  checks: write
 
 jobs:
   version_health:


### PR DESCRIPTION
Auto-created Jira Issue: https://doximity.atlassian.net/browse/IA-3967

---

To support improvements in the workflow, the checks permissions is required for the caller workflow.

[_Created by Sourcegraph batch change `anovadox/update-version-health-workflow-permissions`._](https://doximity.sourcegraphcloud.com/users/anovadox/batch-changes/update-version-health-workflow-permissions)
