### PR TITLE
Add octo-sts token policy for pull-request workflows

### DIFF
--- a/.github/chainguard/pull-request.sts.yaml
+++ b/.github/chainguard/pull-request.sts.yaml
@@ -1,0 +1,7 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: repo:doximity/neo4j-http:ref:refs/heads/.*
+
+permissions:
+  contents: write
+  pull_requests: write
+  actions: write


### PR DESCRIPTION
Auto-created Jira Issue: https://doximity.atlassian.net/browse/IA-5249

---

## Why this change makes sense
- We're trying to eliminate long-lived access tokens, and we're starting with the one that has the most access: `DOXBOT_GH_TOKEN`.
- This access policy file empowers the repo to get a temporary github token from [dox-octo-sts](https://github.com/apps/dox-octo-sts) (repo: https://github.com/doximity/dox-octo-sts) for the purposes of writing commits and creating PRs. 
- This file needs to be merged into the default branch (master) before workflows can successfully use it to acquire a token. 

### Why do we want that?
Github won't let the default `GITHUB_TOKEN` available in GHA workflows trigger other GHA workflows when they create commits or PRs, which will result in required checks not being run.

**We want to update the version-bump PR workflows (for gem and js package releases) to not use the `DOXBOT_GH_TOKEN`**

[_Created by Sourcegraph batch change `anovadox/octo-sts-pull-request-policy`._](https://doximity.sourcegraphcloud.com/users/anovadox/batch-changes/octo-sts-pull-request-policy)
