### PR TITLE
Add `id-token: write` permission to workflows which open PRs

### DIFF
--- a/.github/workflows/gem_create_bump_version_pr.yml
+++ b/.github/workflows/gem_create_bump_version_pr.yml
@@ -21,4 +21,5 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     secrets: inherit


### PR DESCRIPTION
Auto-created Jira Issue: https://doximity.atlassian.net/browse/IA-5373

---

## Why this change makes sense
- We're trying to eliminate long-lived access tokens, and we're starting with the one that has the most access: `DOXBOT_GH_TOKEN`.
- Caller Workflows which use `gem_create_bump_version_pr.yml` or `js_create_bump_version_pr.yml` need the id-token: write permission in order to get an OIDC token from github, which the workflow can use to get a temporary token from octo-sts.

### Why do we want that?
Github won't let the default `GITHUB_TOKEN` available in GHA workflows trigger other GHA workflows when they create commits or PRs, which will result in required checks not being run.

**We want to update the version-bump PR workflows (for gem and js package releases) to not use the `DOXBOT_GH_TOKEN`**

[_Created by Sourcegraph batch change `anovadox/add-id-token-permissions`._](https://doximity.sourcegraphcloud.com/users/anovadox/batch-changes/add-id-token-permissions)
